### PR TITLE
Dynamically set the deployment type for the configmap name

### DIFF
--- a/roles/installer/templates/tower_deployment.yaml.j2
+++ b/roles/installer/templates/tower_deployment.yaml.j2
@@ -240,7 +240,7 @@ spec:
           emptyDir: {}
         - name: {{ meta.name }}-receptor-config
           configMap:
-            name: {{ meta.name }}-awx-configmap
+            name: '{{ meta.name }}-{{ deployment_type }}-configmap'
             items:
               - key: receptor_conf
                 path: receptor.conf


### PR DESCRIPTION
For Tower deployments, the configmap name is currently set incorrectly to tower-awx-configmap. As a result, the receptor config is unable to mount.